### PR TITLE
Adds ability to removeListener when in the same emit loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function EE(fn, context, once) {
   this.fn = fn;
   this.context = context;
   this.once = once || false;
+  this.skip = false;
 }
 
 /**
@@ -144,6 +145,7 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
 
     for (i = 0; i < length; i++) {
       if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+      if (listeners[i].skip) continue;
 
       switch (len) {
         case 1: listeners[i].fn.call(listeners[i].context); break;
@@ -236,6 +238,9 @@ EventEmitter.prototype.removeListener = function removeListener(event, fn, conte
     }
   } else {
     for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+      if (!once && listeners[i].fn === fn) {
+        listeners[i].skip = true;
+      }
       if (
            listeners[i].fn !== fn
         || (once && !listeners[i].once)

--- a/test.js
+++ b/test.js
@@ -504,6 +504,29 @@ describe('EventEmitter', function tests() {
       assume(e.listeners('foo')).eql([]);
       assume(e._eventsCount).equals(0);
     });
+
+    it('removes a listener when removed as part handler callback', function() {
+      var e = new EventEmitter()
+        , foo = { bar: true }
+        , calledThird = 0;
+
+      function first() {
+        foo = null;
+        e.removeListener('update', second);
+      }
+      function second() {
+        assume(foo.bar).equals(true);
+      }
+      function third() {
+        calledThird++;
+      }
+      e.on('update', first);
+      e.on('update', second);
+      e.on('update', third);
+      e.once('update', third);
+      e.emit('update');
+      assume(calledThird).equals(2);
+    });
   });
 
   describe('EventEmitter#removeAllListeners', function () {

--- a/test.js
+++ b/test.js
@@ -522,6 +522,7 @@ describe('EventEmitter', function tests() {
       }
       e.on('update', first);
       e.on('update', second);
+      e.once('update', second);
       e.on('update', third);
       e.once('update', third);
       e.emit('update');


### PR DESCRIPTION
## Overview

This PR fixes a bug when trying to remove an event listener immediately when the `removeListener ` call present in one of the listeners of the stack currently being called. 

### Bug Example

```js
var e = new EventEmitter();
var foo = { bar: true };

function first(){
    foo = null;
    console.log("first");
    e.removeListener('update', second);
}
function second(){
    // this should never get called!
    console.log("second", foo.bar);
}
function third(){
   console.log("third");
}
e.on('update', first);
e.on('update', second);
e.on('update', third);
e.emit('update');
// should log: "first", "third"
```